### PR TITLE
feat - > Don't show filter players

### DIFF
--- a/proxy/src/main/java/ru/leymooo/botfilter/config/Settings.java
+++ b/proxy/src/main/java/ru/leymooo/botfilter/config/Settings.java
@@ -49,7 +49,7 @@ public class Settings extends Config
     @Comment("Проверять ли на бота при заходе на сервер во время бот атаки, не зависимо проходил ли проверку или нет")
     public boolean FORCE_CHECK_ON_ATTACK = true;
     @Comment("Показывать ли онлайн с фильтра")
-    public boolean SHOW_ONLINE = true;
+    public boolean SHOW_ONLINE = false;
     @Comment("Сколько времени есть у игрока чтобы пройти защиту. В миллисекундах. 1 сек = 1000")
     public int TIME_OUT = 12700;
     @Comment("Включить ли фикс от 'Team 'xxx' already exist in this scoreboard'")


### PR DESCRIPTION
This is a problem, if you have a player limit and the filter fills up, it will expect the server to be full and not let others in, and it causes some other problems with MOTD plugins, it would be best to leave it disabled by default.