### PR TITLE
GitHub Actions fix

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,5 +29,5 @@ jobs:
     - run: mvn --activate-profiles dist --no-transfer-progress package
     - uses: actions/upload-artifact@v4
       with:
-        name: BungeeCord
+        name: BungeeCord-Java-${{ matrix.java }}
         path: bootstrap/target/BungeeCord.jar

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -27,7 +27,7 @@ jobs:
           ${{ runner.os }}-maven-
     - run: java -version && mvn --version
     - run: mvn --activate-profiles dist --no-transfer-progress package
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: BungeeCord
         path: bootstrap/target/BungeeCord.jar


### PR DESCRIPTION
Current Workflow fails because actions in use are outdated.

Actions were updated to the supported version and artifact names were changed to include Java version and avoid conflicts.